### PR TITLE
ADAPT-389 Change main navigation to be left-aligned

### DIFF
--- a/templates/menu/menu--main.html.twig
+++ b/templates/menu/menu--main.html.twig
@@ -1,0 +1,33 @@
+{#
+/**
+ * @file
+ * Main Navigation Component
+ *
+ * A navigation menu for the website.
+ *
+ * Available variables:
+ * - attributes: For additional HTML attributes not already provided.
+ * - modifier_class: Additional css classes to change look and behaviour of the component.
+ * - toggle_modifier_class: Additional css classes to change look and behaviour of the toggle.
+ * - aria_label: Aria label for the <nav> element. Default is "main menu". If there are multiple instances of the component on the same page, use a different aria_label for each instance.
+ *
+ */
+#}
+{% set toggle_text = "Menu"|t %}
+{% set attributes = attributes.addClass(['su-multi-menu', 'su-multi-menu--buttons', 'su-multi-menu--left', 'no-js']) %}
+{% set attributes = attributes.setAttribute('aria-label', 'main menu') %}
+{# Macros #}
+{%- import "@basic/menus/macros/nav-menu.twig" as menus -%}
+<nav{{ attributes }}>
+  {% block multimenubutton %}
+    <button class="su-multi-menu__nav-toggle su-multi-menu__nav-toggle--right {{ toggle_modifier_class }}" aria-expanded="false">{{ toggle_text|default('Menu') }}</button>
+  {% endblock %}
+  {% spaceless %}
+    {% if items is iterable %}
+      {{ menus.nav_menu(items, 1, 'su-multi-menu') }}
+    {% else %}
+      {# If custom markup is provided, emit it as is #}
+      {{ items }}
+    {% endif %}
+  {% endspaceless %}
+</nav>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Change main navigation to be left-aligned

# Review By (Date)
- asap

# Urgency
- low

# Steps to Test

1. Pull this branch to local
2. Flush render cache
3. Main nav should now appear left-aligned. Compare to the [SAA Design System on Figma](https://www.figma.com/file/TXNBECAGcEkZ3vwc6xcZ3g/SAA-Design-System)


# Associated Issues and/or People
- [ADAPT-389](https://stanfordits.atlassian.net/browse/ADAPT-389)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
