### PR TITLE
ADAPT-454 Hide masthead theme appearance settings

### DIFF
--- a/theme-settings.php
+++ b/theme-settings.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * SAA Theme Settings
+ * SAA Theme Settings.
  */
 
 use Drupal\Core\Form\FormStateInterface;

--- a/theme-settings.php
+++ b/theme-settings.php
@@ -1,0 +1,54 @@
+<?php
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+use Drupal\Core\Link;
+use Drupal\Core\Render\Markup;
+
+// Set theme name to use in the key values.
+$theme_name = \Drupal::theme()->getActiveTheme()->getName();
+
+/**
+ * Implements hook_form_system_theme_settings_alter().
+ */
+function saa_victoria_subtheme_form_system_theme_settings_alter(array &$form, FormStateInterface $form_state) {
+  $form['options_settings'] = [
+    '#type' => 'fieldset',
+    '#title' => t('Theme Specific Settings'),
+  ];
+
+
+  // BrowserSync support.
+  $form['options_settings']['stanford_basic_browser_sync'] = [
+    '#type' => 'fieldset',
+    '#title' => t('BrowserSync Settings'),
+  ];
+  $form['options_settings']['stanford_basic_browser_sync']['browser_sync']['#tree'] = TRUE;
+  $form['options_settings']['stanford_basic_browser_sync']['browser_sync']['enabled'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Enable BrowserSync support for theme'),
+    '#default_value' => theme_get_setting('browser_sync.enabled'),
+    '#description' => t("Checking this box will automatically add the BrowserSync JS to your theme for development."),
+  ];
+
+  $form['options_settings']['stanford_basic_browser_sync']['browser_sync']['host'] = [
+    '#type' => 'textfield',
+    '#title' => t('BrowserSync host'),
+    '#default_value' => theme_get_setting('browser_sync.host'),
+    '#description' => t("Default: localhost. Enter 'HOST' which will be replaced by your site's hostname."),
+    '#states' => [
+      'visible' => [':input[name="browser_sync[enabled]"]' => ['checked' => TRUE]],
+    ],
+  ];
+
+  $form['options_settings']['stanford_basic_browser_sync']['browser_sync']['port'] = [
+    '#type' => 'number',
+    '#title' => t('Enable BrowserSync support for theme'),
+    '#default_value' => theme_get_setting('browser_sync.port'),
+    '#description' => t("Default: '3000'."),
+    '#states' => [
+      'visible' => [':input[name="browser_sync[enabled]"]' => ['checked' => TRUE]],
+    ],
+  ];
+
+}

--- a/theme-settings.php
+++ b/theme-settings.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
+ * @file
  * SAA Theme Settings
- * Additional theme settings form
  */
 
 use Drupal\Core\Form\FormStateInterface;

--- a/theme-settings.php
+++ b/theme-settings.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * SAA Theme Settings
+ * Additional theme settings form
+ */
+
 use Drupal\Core\Form\FormStateInterface;
 
 // Set theme name to use in the key values.

--- a/theme-settings.php
+++ b/theme-settings.php
@@ -3,6 +3,7 @@
 /**
  * @file
  * SAA Theme Settings.
+ * Note: Theme settings are close to Stanford Basic but hide brandbar and masthead style options, since those are enforced with custom styles in this theme.
  */
 
 use Drupal\Core\Form\FormStateInterface;

--- a/theme-settings.php
+++ b/theme-settings.php
@@ -1,9 +1,6 @@
 <?php
 
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Url;
-use Drupal\Core\Link;
-use Drupal\Core\Render\Markup;
 
 // Set theme name to use in the key values.
 $theme_name = \Drupal::theme()->getActiveTheme()->getName();
@@ -16,7 +13,6 @@ function saa_victoria_subtheme_form_system_theme_settings_alter(array &$form, Fo
     '#type' => 'fieldset',
     '#title' => t('Theme Specific Settings'),
   ];
-
 
   // BrowserSync support.
   $form['options_settings']['stanford_basic_browser_sync'] = [
@@ -50,5 +46,4 @@ function saa_victoria_subtheme_form_system_theme_settings_alter(array &$form, Fo
       'visible' => [':input[name="browser_sync[enabled]"]' => ['checked' => TRUE]],
     ],
   ];
-
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Hide masthead theme appearance settings

# Review By (Date)
- 07/15

# Urgency
- low
# Steps to Test

1. Pull this branch
2. Clear cache
4. View appearance page `admin/appearance/settings/saa_victoria_subtheme`

# Associated Issues and/or People
- [ADAPT-454](https://stanfordits.atlassian.net/browse/ADAPT-454) 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
