### PR TITLE
ADAPT-000 Update brand bar logo destination

### DIFF
--- a/templates/components/brand-bar/saa--brand-bar.html.twig
+++ b/templates/components/brand-bar/saa--brand-bar.html.twig
@@ -15,5 +15,5 @@
  */
 #}
 <div class="su-brand-bar {{ modifier_class }}">
-  <div class="su-brand-bar__container"><a {{ attributes }} class="su-brand-bar__logo" href="https://stanford.edu"><img src="{{ base_path ~ directory }}/dist/assets/svg/saa-logo.svg" alt="Stanford Alumni" class="su-brand-bar__img" /></a></div>
+  <div class="su-brand-bar__container"><a {{ attributes }} class="su-brand-bar__logo" href="https://alumni.stanford.edu/"><img src="{{ base_path ~ directory }}/dist/assets/svg/saa-logo.svg" alt="Stanford Alumni" class="su-brand-bar__img" /></a></div>
 </div>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Update brand bar logo destination

# Review By (Date)
- 07/20

# Urgency
- low

# Steps to Test

1. Pull this branch to local
2. Clear site cache
3. Stanford | Alumni logo in brand bar should go to https://alumni.stanford.edu 


# Associated Issues and/or People
- [ADAPT-476](https://stanfordits.atlassian.net/browse/ADAPT-476)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
