### PR TITLE
ADAPT-687: Removed skip link extra link and added page content id to …

### DIFF
--- a/templates/page.html.twig
+++ b/templates/page.html.twig
@@ -16,8 +16,7 @@
   </section>
 </header>
 
-<div class="page-content">
-  <a name="page-content" id="page-content" tabindex="-1" class="visually-hidden focusable">Page Content</a>
+<div id="page-content" class="page-content">
   {{ page.content }}
 </div>
 


### PR DESCRIPTION
…main section.

# READY FOR REVIEW
# Summary
- Remove unneccessary skip link extra link for old destination
- moved the page-content id to the correct div instead, 

# Review By (Date)
- 9/11 if possible  - @yvonnetangsu see discussion here: https://stanfordwebservices.slack.com/archives/GJQJ7HTK7/p1599762317152200

# Urgency
- How critical is this PR?

# Steps to Test

1. Pull down the branch
2. Clear the site cache
3. Make sure nothing on the page changes for now visually.
4. the page-content id should now be on the containing div, not a skiplink destination link.
Note that my next step is to look at how we do the page template, masthead templates so we can inherit & extend more. I will have multiple branches for this task.
You can test also on this dev site that has this branch and the update from core: 
https://adaptdemo-dev.sites.stanford.edu/
But please test locally too if possible with an updated version of cardinalsites.

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- JIRA ticket ADAPT-687
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
