### PR TITLE
ADAPT-708: Fixed accessible names for nav sections in the footer.

### DIFF
--- a/templates/components/fat-footer/saa-fat-footer.html.twig
+++ b/templates/components/fat-footer/saa-fat-footer.html.twig
@@ -106,7 +106,7 @@
 
 {% block contentcell2 %}
   {# Link SEction 1 - top left links. #}
-  <nav class="saa-local-footer__links-section saa-local-footer__links-section-1" aria-label="footer primary nav">
+  <nav class="saa-local-footer__links-section saa-local-footer__links-section-1" aria-label="saa footer section 1">
     <h2 class="su-local-footer__list-heading">Events</h2>
     <ul class="saa-local-footer__links-column-1">
       <li><a href="https://alumni.stanford.edu/get/page/events">Explore all events</a></li>
@@ -115,7 +115,7 @@
     </ul>
   </nav>
   {# Link SEction 1 - top left links. #}
-  <nav class="saa-local-footer__links-section saa-local-footer__links-section-2" aria-label="footer primary nav">
+  <nav class="saa-local-footer__links-section saa-local-footer__links-section-2" aria-label="saa footer section 2">
     <h2 class="su-local-footer__list-heading">Communities</h2>
     <ul class="saa-local-footer__links-column-2">
       <li><a href="https://alumni.stanford.edu/get/page/groups/main">Clubs & groups</a></li>
@@ -125,7 +125,7 @@
     </ul>
   </nav>
   {# Link SEction 1 - top left links. #}
-  <nav class="saa-local-footer__links-section saa-local-footer__links-section-3" aria-label="footer primary nav">
+  <nav class="saa-local-footer__links-section saa-local-footer__links-section-3" aria-label="saa footer section 3">
     <h2 class="su-local-footer__list-heading">Reading & resources</h2>
     <ul class="saa-local-footer__links-column-3">
 {#      <li><a href="/">News/Announcements</a></li>#}
@@ -135,7 +135,7 @@
       <li><a href="https://alumni.stanford.edu/get/page/life-long-learning/learn-join">Newsletters</a></li>
     </ul>
   </nav>
-  <nav class="saa-local-footer__links-section saa-local-footer__links-section-4" aria-label="footer primary nav">
+  <nav class="saa-local-footer__links-section saa-local-footer__links-section-4" aria-label="saa footer section 4">
     <h2 class="su-local-footer__list-heading">Programs & perks</h2>
     <ul class="saa-local-footer__links-column-4">
       <li><a href="https://alumni.stanford.edu/get/page/perks/index">Alumni perks</a></li>
@@ -147,7 +147,7 @@
     </ul>
   </nav>
   {# Link SEction 1 - top left links. #}
-  <nav class="saa-local-footer__links-section saa-local-footer__links-section-5" aria-label="footer primary nav">
+  <nav class="saa-local-footer__links-section saa-local-footer__links-section-5" aria-label="saa footer section 5">
     <h2 class="su-local-footer__list-heading">Volunteer</h2>
     <ul class="saa-local-footer__links-column-5">
       <li><a href="https://alumni.stanford.edu/get/page/landing/volunteering">Getting started</a></li>
@@ -157,7 +157,7 @@
     </ul>
   </nav>
   {# Link SEction 1 - top left links. #}
-  <nav class="saa-local-footer__links-section saa-local-footer__links-section-6" aria-label="footer primary nav">
+  <nav class="saa-local-footer__links-section saa-local-footer__links-section-6" aria-label="saa footer section 6">
     <h2 class="su-local-footer__list-heading">About</h2>
     <ul class="saa-local-footer__links-column-6">
       <li><a href="https://alumni.stanford.edu/get/page/about-us">About SAA</a></li>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fixed duplicate aria labels 

# Review By (Date)
- 9/22 if possible

# Urgency
- medium, accessibility issue on LIVE sites

# Steps to Test

1. Pull down the branch or check out https://saauserguide-test.sites.stanford.edu/
2. If you have an accessibility test you can run to see accessible names, you can do that
3. Inspect each of the 6 link sections in the footer (right area of the footer) and check that each has a unique aria label now.

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- JIRA ticket ADAPT-708

