### PR TITLE
ADAPT-885: Updated decanter version.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -953,9 +953,9 @@
       }
     },
     "@fortawesome/fontawesome-free": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.13.0.tgz",
-      "integrity": "sha512-xKOeQEl5O47GPZYIMToj6uuA2syyFlq9EMSl2ui0uytjY9xbe8XS0pexNWmxrdcCyNGyDmLyYw5FtKsalBUeOg==",
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.15.1.tgz",
+      "integrity": "sha512-OEdH7SyC1suTdhBGW91/zBfR6qaIhThbcN8PUXtXilY4GYnSBbVqOntdHbC1vXwsDnX0Qix2m2+DSU1J51ybOQ==",
       "dev": true
     },
     "@fullhuman/postcss-purgecss": {
@@ -3283,9 +3283,9 @@
       "dev": true
     },
     "decanter": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/decanter/-/decanter-6.0.5.tgz",
-      "integrity": "sha512-FJnkTgDzteyBlalPxnUz5vYYdz50hBB7kz8RfAzLQt2Q5CaPMS/rsr4au6kAiRWdGb2FqYHlzY4vfQla6yXk3A==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/decanter/-/decanter-6.1.3.tgz",
+      "integrity": "sha512-seGYp2JPn3GaBGOa2OeuvdQNIExRGyDkyLs1M7HPOfaDlpZ6omXYFT8/ev4Mj3jOXSjunoJQVg0n8Qrp9qoTHg==",
       "dev": true,
       "requires": {
         "@fortawesome/fontawesome-free": "^5.12.1",
@@ -7948,7 +7948,6 @@
       "version": "6.14.6",
       "resolved": "https://registry.npmjs.org/npm/-/npm-6.14.6.tgz",
       "integrity": "sha512-axnz6iHFK6WPE0js/+mRp+4IOwpHn5tJEw5KB6FiCU764zmffrhsYHbSHi2kKqNkRBt53XasXjngZfBD3FQzrQ==",
-      "dev": true,
       "requires": {
         "JSONStream": "^1.3.5",
         "abbrev": "~1.1.1",
@@ -8078,7 +8077,6 @@
         "JSONStream": {
           "version": "1.3.5",
           "bundled": true,
-          "dev": true,
           "requires": {
             "jsonparse": "^1.2.0",
             "through": ">=2.2.7 <3"
@@ -8086,13 +8084,11 @@
         },
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "agent-base": {
           "version": "4.3.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "es6-promisify": "^5.0.0"
           }
@@ -8100,7 +8096,6 @@
         "agentkeepalive": {
           "version": "3.5.2",
           "bundled": true,
-          "dev": true,
           "requires": {
             "humanize-ms": "^1.2.1"
           }
@@ -8108,7 +8103,6 @@
         "ajv": {
           "version": "5.5.2",
           "bundled": true,
-          "dev": true,
           "requires": {
             "co": "^4.6.0",
             "fast-deep-equal": "^1.0.0",
@@ -8119,48 +8113,40 @@
         "ansi-align": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "string-width": "^2.0.0"
           }
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "ansi-styles": {
           "version": "3.2.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
         },
         "ansicolors": {
           "version": "0.3.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "ansistyles": {
           "version": "0.1.3",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "aproba": {
           "version": "2.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "archy": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
           "bundled": true,
-          "dev": true,
           "requires": {
             "delegates": "^1.0.0",
             "readable-stream": "^2.0.6"
@@ -8169,7 +8155,6 @@
             "readable-stream": {
               "version": "2.3.6",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -8183,7 +8168,6 @@
             "string_decoder": {
               "version": "1.1.1",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
@@ -8192,46 +8176,38 @@
         },
         "asap": {
           "version": "2.0.6",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "asn1": {
           "version": "0.2.4",
           "bundled": true,
-          "dev": true,
           "requires": {
             "safer-buffer": "~2.1.0"
           }
         },
         "assert-plus": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "asynckit": {
           "version": "0.4.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "aws-sign2": {
           "version": "0.7.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "aws4": {
           "version": "1.8.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "tweetnacl": "^0.14.3"
@@ -8240,7 +8216,6 @@
         "bin-links": {
           "version": "1.1.7",
           "bundled": true,
-          "dev": true,
           "requires": {
             "bluebird": "^3.5.3",
             "cmd-shim": "^3.0.0",
@@ -8252,13 +8227,11 @@
         },
         "bluebird": {
           "version": "3.5.5",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "boxen": {
           "version": "1.3.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "ansi-align": "^2.0.0",
             "camelcase": "^4.0.0",
@@ -8272,7 +8245,6 @@
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -8280,28 +8252,23 @@
         },
         "buffer-from": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "builtins": {
           "version": "1.0.3",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "byline": {
           "version": "5.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "byte-size": {
           "version": "5.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "cacache": {
           "version": "12.0.3",
           "bundled": true,
-          "dev": true,
           "requires": {
             "bluebird": "^3.5.5",
             "chownr": "^1.1.1",
@@ -8322,28 +8289,23 @@
         },
         "call-limit": {
           "version": "1.1.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "camelcase": {
           "version": "4.1.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "capture-stack-trace": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "caseless": {
           "version": "0.12.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "chalk": {
           "version": "2.4.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -8352,31 +8314,26 @@
         },
         "chownr": {
           "version": "1.1.4",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "ci-info": {
           "version": "2.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "cidr-regex": {
           "version": "2.0.10",
           "bundled": true,
-          "dev": true,
           "requires": {
             "ip-regex": "^2.1.0"
           }
         },
         "cli-boxes": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "cli-columns": {
           "version": "3.1.2",
           "bundled": true,
-          "dev": true,
           "requires": {
             "string-width": "^2.0.0",
             "strip-ansi": "^3.0.1"
@@ -8385,7 +8342,6 @@
         "cli-table3": {
           "version": "0.5.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "colors": "^1.1.2",
             "object-assign": "^4.1.0",
@@ -8395,7 +8351,6 @@
         "cliui": {
           "version": "4.1.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "string-width": "^2.1.1",
             "strip-ansi": "^4.0.0",
@@ -8404,13 +8359,11 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "strip-ansi": {
               "version": "4.0.0",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "ansi-regex": "^3.0.0"
               }
@@ -8419,13 +8372,11 @@
         },
         "clone": {
           "version": "1.0.4",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "cmd-shim": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "mkdirp": "~0.5.0"
@@ -8433,37 +8384,31 @@
         },
         "co": {
           "version": "4.6.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "color-convert": {
           "version": "1.9.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "color-name": "^1.1.1"
           }
         },
         "color-name": {
           "version": "1.1.3",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "colors": {
           "version": "1.3.3",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "columnify": {
           "version": "1.5.4",
           "bundled": true,
-          "dev": true,
           "requires": {
             "strip-ansi": "^3.0.0",
             "wcwidth": "^1.0.0"
@@ -8472,20 +8417,17 @@
         "combined-stream": {
           "version": "1.0.6",
           "bundled": true,
-          "dev": true,
           "requires": {
             "delayed-stream": "~1.0.0"
           }
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "concat-stream": {
           "version": "1.6.2",
           "bundled": true,
-          "dev": true,
           "requires": {
             "buffer-from": "^1.0.0",
             "inherits": "^2.0.3",
@@ -8496,7 +8438,6 @@
             "readable-stream": {
               "version": "2.3.6",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -8510,7 +8451,6 @@
             "string_decoder": {
               "version": "1.1.1",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
@@ -8520,7 +8460,6 @@
         "config-chain": {
           "version": "1.1.12",
           "bundled": true,
-          "dev": true,
           "requires": {
             "ini": "^1.3.4",
             "proto-list": "~1.2.1"
@@ -8529,7 +8468,6 @@
         "configstore": {
           "version": "3.1.2",
           "bundled": true,
-          "dev": true,
           "requires": {
             "dot-prop": "^4.1.0",
             "graceful-fs": "^4.1.2",
@@ -8541,13 +8479,11 @@
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "copy-concurrently": {
           "version": "1.0.5",
           "bundled": true,
-          "dev": true,
           "requires": {
             "aproba": "^1.1.1",
             "fs-write-stream-atomic": "^1.0.8",
@@ -8559,25 +8495,21 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "iferr": {
               "version": "0.1.5",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             }
           }
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "create-error-class": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
           "requires": {
             "capture-stack-trace": "^1.0.0"
           }
@@ -8585,7 +8517,6 @@
         "cross-spawn": {
           "version": "5.1.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "lru-cache": "^4.0.1",
             "shebang-command": "^1.2.0",
@@ -8595,7 +8526,6 @@
             "lru-cache": {
               "version": "4.1.5",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "pseudomap": "^1.0.2",
                 "yallist": "^2.1.2"
@@ -8603,25 +8533,21 @@
             },
             "yallist": {
               "version": "2.1.2",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             }
           }
         },
         "crypto-random-string": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "cyclist": {
           "version": "0.2.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "dashdash": {
           "version": "1.14.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "assert-plus": "^1.0.0"
           }
@@ -8629,42 +8555,35 @@
         "debug": {
           "version": "3.1.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           },
           "dependencies": {
             "ms": {
               "version": "2.0.0",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             }
           }
         },
         "debuglog": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "decamelize": {
           "version": "1.2.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "decode-uri-component": {
           "version": "0.2.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "deep-extend": {
           "version": "0.6.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "defaults": {
           "version": "1.0.3",
           "bundled": true,
-          "dev": true,
           "requires": {
             "clone": "^1.0.2"
           }
@@ -8672,35 +8591,29 @@
         "define-properties": {
           "version": "1.1.3",
           "bundled": true,
-          "dev": true,
           "requires": {
             "object-keys": "^1.0.12"
           }
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "detect-indent": {
           "version": "5.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "detect-newline": {
           "version": "2.1.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "dezalgo": {
           "version": "1.0.3",
           "bundled": true,
-          "dev": true,
           "requires": {
             "asap": "^2.0.0",
             "wrappy": "1"
@@ -8709,25 +8622,21 @@
         "dot-prop": {
           "version": "4.2.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "is-obj": "^1.0.0"
           }
         },
         "dotenv": {
           "version": "5.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "duplexer3": {
           "version": "0.1.4",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "duplexify": {
           "version": "3.6.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "end-of-stream": "^1.0.0",
             "inherits": "^2.0.1",
@@ -8738,7 +8647,6 @@
             "readable-stream": {
               "version": "2.3.6",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -8752,7 +8660,6 @@
             "string_decoder": {
               "version": "1.1.1",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
@@ -8762,7 +8669,6 @@
         "ecc-jsbn": {
           "version": "0.1.2",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "jsbn": "~0.1.0",
@@ -8771,13 +8677,11 @@
         },
         "editor": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "encoding": {
           "version": "0.1.12",
           "bundled": true,
-          "dev": true,
           "requires": {
             "iconv-lite": "~0.4.13"
           }
@@ -8785,25 +8689,21 @@
         "end-of-stream": {
           "version": "1.4.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "once": "^1.4.0"
           }
         },
         "env-paths": {
           "version": "2.2.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "err-code": {
           "version": "1.1.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "errno": {
           "version": "0.1.7",
           "bundled": true,
-          "dev": true,
           "requires": {
             "prr": "~1.0.1"
           }
@@ -8811,7 +8711,6 @@
         "es-abstract": {
           "version": "1.12.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "es-to-primitive": "^1.1.1",
             "function-bind": "^1.1.1",
@@ -8823,7 +8722,6 @@
         "es-to-primitive": {
           "version": "1.2.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "is-callable": "^1.1.4",
             "is-date-object": "^1.0.1",
@@ -8832,26 +8730,22 @@
         },
         "es6-promise": {
           "version": "4.2.8",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "es6-promisify": {
           "version": "5.0.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "es6-promise": "^4.0.3"
           }
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "execa": {
           "version": "0.7.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "cross-spawn": "^5.0.1",
             "get-stream": "^3.0.0",
@@ -8864,45 +8758,37 @@
           "dependencies": {
             "get-stream": {
               "version": "3.0.0",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             }
           }
         },
         "extend": {
           "version": "3.0.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "extsprintf": {
           "version": "1.3.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "fast-deep-equal": {
           "version": "1.1.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "fast-json-stable-stringify": {
           "version": "2.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "figgy-pudding": {
           "version": "3.5.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "find-npm-prefix": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "find-up": {
           "version": "2.1.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "locate-path": "^2.0.0"
           }
@@ -8910,7 +8796,6 @@
         "flush-write-stream": {
           "version": "1.0.3",
           "bundled": true,
-          "dev": true,
           "requires": {
             "inherits": "^2.0.1",
             "readable-stream": "^2.0.4"
@@ -8919,7 +8804,6 @@
             "readable-stream": {
               "version": "2.3.6",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -8933,7 +8817,6 @@
             "string_decoder": {
               "version": "1.1.1",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
@@ -8942,13 +8825,11 @@
         },
         "forever-agent": {
           "version": "0.6.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "form-data": {
           "version": "2.3.2",
           "bundled": true,
-          "dev": true,
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "1.0.6",
@@ -8958,7 +8839,6 @@
         "from2": {
           "version": "2.3.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "inherits": "^2.0.1",
             "readable-stream": "^2.0.0"
@@ -8967,7 +8847,6 @@
             "readable-stream": {
               "version": "2.3.6",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -8981,7 +8860,6 @@
             "string_decoder": {
               "version": "1.1.1",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
@@ -8991,7 +8869,6 @@
         "fs-minipass": {
           "version": "1.2.7",
           "bundled": true,
-          "dev": true,
           "requires": {
             "minipass": "^2.6.0"
           },
@@ -8999,7 +8876,6 @@
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -9010,7 +8886,6 @@
         "fs-vacuum": {
           "version": "1.2.10",
           "bundled": true,
-          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "path-is-inside": "^1.0.1",
@@ -9020,7 +8895,6 @@
         "fs-write-stream-atomic": {
           "version": "1.0.10",
           "bundled": true,
-          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "iferr": "^0.1.5",
@@ -9030,13 +8904,11 @@
           "dependencies": {
             "iferr": {
               "version": "0.1.5",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "readable-stream": {
               "version": "2.3.6",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -9050,7 +8922,6 @@
             "string_decoder": {
               "version": "1.1.1",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
@@ -9059,18 +8930,15 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "function-bind": {
           "version": "1.1.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "gauge": {
           "version": "2.7.4",
           "bundled": true,
-          "dev": true,
           "requires": {
             "aproba": "^1.0.3",
             "console-control-strings": "^1.0.0",
@@ -9084,13 +8952,11 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -9101,13 +8967,11 @@
         },
         "genfun": {
           "version": "5.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "gentle-fs": {
           "version": "2.3.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "aproba": "^1.1.2",
             "chownr": "^1.1.2",
@@ -9124,25 +8988,21 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "iferr": {
               "version": "0.1.5",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             }
           }
         },
         "get-caller-file": {
           "version": "1.0.3",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "get-stream": {
           "version": "4.1.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "pump": "^3.0.0"
           }
@@ -9150,7 +9010,6 @@
         "getpass": {
           "version": "0.1.7",
           "bundled": true,
-          "dev": true,
           "requires": {
             "assert-plus": "^1.0.0"
           }
@@ -9158,7 +9017,6 @@
         "glob": {
           "version": "7.1.6",
           "bundled": true,
-          "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -9171,7 +9029,6 @@
         "global-dirs": {
           "version": "0.1.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "ini": "^1.3.4"
           }
@@ -9179,7 +9036,6 @@
         "got": {
           "version": "6.7.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "create-error-class": "^3.0.0",
             "duplexer3": "^0.1.4",
@@ -9196,25 +9052,21 @@
           "dependencies": {
             "get-stream": {
               "version": "3.0.0",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             }
           }
         },
         "graceful-fs": {
           "version": "4.2.4",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "har-schema": {
           "version": "2.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "har-validator": {
           "version": "5.1.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "ajv": "^5.3.0",
             "har-schema": "^2.0.0"
@@ -9223,40 +9075,33 @@
         "has": {
           "version": "1.0.3",
           "bundled": true,
-          "dev": true,
           "requires": {
             "function-bind": "^1.1.1"
           }
         },
         "has-flag": {
           "version": "3.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "has-symbols": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "hosted-git-info": {
           "version": "2.8.8",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "http-cache-semantics": {
           "version": "3.8.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "http-proxy-agent": {
           "version": "2.1.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "agent-base": "4",
             "debug": "3.1.0"
@@ -9265,7 +9110,6 @@
         "http-signature": {
           "version": "1.2.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "assert-plus": "^1.0.0",
             "jsprim": "^1.2.2",
@@ -9275,7 +9119,6 @@
         "https-proxy-agent": {
           "version": "2.2.4",
           "bundled": true,
-          "dev": true,
           "requires": {
             "agent-base": "^4.3.0",
             "debug": "^3.1.0"
@@ -9284,7 +9127,6 @@
         "humanize-ms": {
           "version": "1.2.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "ms": "^2.0.0"
           }
@@ -9292,43 +9134,36 @@
         "iconv-lite": {
           "version": "0.4.23",
           "bundled": true,
-          "dev": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
           }
         },
         "iferr": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "ignore-walk": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
           "requires": {
             "minimatch": "^3.0.4"
           }
         },
         "import-lazy": {
           "version": "2.1.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "infer-owner": {
           "version": "1.0.4",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
-          "dev": true,
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -9336,18 +9171,15 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "init-package-json": {
           "version": "1.10.3",
           "bundled": true,
-          "dev": true,
           "requires": {
             "glob": "^7.1.1",
             "npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
@@ -9361,56 +9193,47 @@
         },
         "invert-kv": {
           "version": "2.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "ip": {
           "version": "1.1.5",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "ip-regex": {
           "version": "2.1.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "is-callable": {
           "version": "1.1.4",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "is-ci": {
           "version": "1.2.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "ci-info": "^1.5.0"
           },
           "dependencies": {
             "ci-info": {
               "version": "1.6.0",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             }
           }
         },
         "is-cidr": {
           "version": "3.0.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "cidr-regex": "^2.0.10"
           }
         },
         "is-date-object": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -9418,7 +9241,6 @@
         "is-installed-globally": {
           "version": "0.1.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "global-dirs": "^0.1.0",
             "is-path-inside": "^1.0.0"
@@ -9426,108 +9248,89 @@
         },
         "is-npm": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "is-obj": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "is-path-inside": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "path-is-inside": "^1.0.1"
           }
         },
         "is-redirect": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "is-regex": {
           "version": "1.0.4",
           "bundled": true,
-          "dev": true,
           "requires": {
             "has": "^1.0.1"
           }
         },
         "is-retry-allowed": {
           "version": "1.2.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "is-stream": {
           "version": "1.1.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "is-symbol": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
           "requires": {
             "has-symbols": "^1.0.0"
           }
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "isexe": {
           "version": "2.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "isstream": {
           "version": "0.1.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "jsbn": {
           "version": "0.1.1",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "json-parse-better-errors": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "json-schema": {
           "version": "0.2.3",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "json-schema-traverse": {
           "version": "0.3.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "jsonparse": {
           "version": "1.3.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "jsprim": {
           "version": "1.4.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "assert-plus": "1.0.0",
             "extsprintf": "1.3.0",
@@ -9538,20 +9341,17 @@
         "latest-version": {
           "version": "3.1.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "package-json": "^4.0.0"
           }
         },
         "lazy-property": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "lcid": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "invert-kv": "^2.0.0"
           }
@@ -9559,7 +9359,6 @@
         "libcipm": {
           "version": "4.0.7",
           "bundled": true,
-          "dev": true,
           "requires": {
             "bin-links": "^1.1.2",
             "bluebird": "^3.5.1",
@@ -9581,7 +9380,6 @@
         "libnpm": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "bin-links": "^1.1.2",
             "bluebird": "^3.5.3",
@@ -9608,7 +9406,6 @@
         "libnpmaccess": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
           "requires": {
             "aproba": "^2.0.0",
             "get-stream": "^4.0.0",
@@ -9619,7 +9416,6 @@
         "libnpmconfig": {
           "version": "1.2.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "figgy-pudding": "^3.5.1",
             "find-up": "^3.0.0",
@@ -9629,7 +9425,6 @@
             "find-up": {
               "version": "3.0.0",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "locate-path": "^3.0.0"
               }
@@ -9637,7 +9432,6 @@
             "locate-path": {
               "version": "3.0.0",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "p-locate": "^3.0.0",
                 "path-exists": "^3.0.0"
@@ -9646,7 +9440,6 @@
             "p-limit": {
               "version": "2.2.0",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "p-try": "^2.0.0"
               }
@@ -9654,22 +9447,19 @@
             "p-locate": {
               "version": "3.0.0",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "p-limit": "^2.0.0"
               }
             },
             "p-try": {
               "version": "2.2.0",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             }
           }
         },
         "libnpmhook": {
           "version": "5.0.3",
           "bundled": true,
-          "dev": true,
           "requires": {
             "aproba": "^2.0.0",
             "figgy-pudding": "^3.4.1",
@@ -9680,7 +9470,6 @@
         "libnpmorg": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "aproba": "^2.0.0",
             "figgy-pudding": "^3.4.1",
@@ -9691,7 +9480,6 @@
         "libnpmpublish": {
           "version": "1.1.2",
           "bundled": true,
-          "dev": true,
           "requires": {
             "aproba": "^2.0.0",
             "figgy-pudding": "^3.5.1",
@@ -9707,7 +9495,6 @@
         "libnpmsearch": {
           "version": "2.0.2",
           "bundled": true,
-          "dev": true,
           "requires": {
             "figgy-pudding": "^3.5.1",
             "get-stream": "^4.0.0",
@@ -9717,7 +9504,6 @@
         "libnpmteam": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
           "requires": {
             "aproba": "^2.0.0",
             "figgy-pudding": "^3.4.1",
@@ -9728,7 +9514,6 @@
         "libnpx": {
           "version": "10.2.2",
           "bundled": true,
-          "dev": true,
           "requires": {
             "dotenv": "^5.0.1",
             "npm-package-arg": "^6.0.0",
@@ -9743,7 +9528,6 @@
         "locate-path": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "p-locate": "^2.0.0",
             "path-exists": "^3.0.0"
@@ -9752,7 +9536,6 @@
         "lock-verify": {
           "version": "2.1.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "npm-package-arg": "^6.1.0",
             "semver": "^5.4.1"
@@ -9761,20 +9544,17 @@
         "lockfile": {
           "version": "1.0.4",
           "bundled": true,
-          "dev": true,
           "requires": {
             "signal-exit": "^3.0.2"
           }
         },
         "lodash._baseindexof": {
           "version": "3.1.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "lodash._createset": "~4.0.0",
             "lodash._root": "~3.0.0"
@@ -9782,71 +9562,58 @@
         },
         "lodash._bindcallback": {
           "version": "3.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
           "bundled": true,
-          "dev": true,
           "requires": {
             "lodash._getnative": "^3.0.0"
           }
         },
         "lodash._createset": {
           "version": "4.0.3",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "lodash._getnative": {
           "version": "3.9.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "lodash._root": {
           "version": "3.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "lodash.clonedeep": {
           "version": "4.5.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "lodash.restparam": {
           "version": "3.6.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "lodash.union": {
           "version": "4.6.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "lodash.uniq": {
           "version": "4.5.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "lodash.without": {
           "version": "4.4.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "lowercase-keys": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "lru-cache": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "yallist": "^3.0.2"
           }
@@ -9854,7 +9621,6 @@
         "make-dir": {
           "version": "1.3.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "pify": "^3.0.0"
           }
@@ -9862,7 +9628,6 @@
         "make-fetch-happen": {
           "version": "5.0.2",
           "bundled": true,
-          "dev": true,
           "requires": {
             "agentkeepalive": "^3.4.1",
             "cacache": "^12.0.0",
@@ -9880,20 +9645,17 @@
         "map-age-cleaner": {
           "version": "0.1.3",
           "bundled": true,
-          "dev": true,
           "requires": {
             "p-defer": "^1.0.0"
           }
         },
         "meant": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "mem": {
           "version": "4.3.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "map-age-cleaner": "^0.1.1",
             "mimic-fn": "^2.0.0",
@@ -9902,20 +9664,17 @@
           "dependencies": {
             "mimic-fn": {
               "version": "2.1.0",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             }
           }
         },
         "mime-db": {
           "version": "1.35.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "mime-types": {
           "version": "2.1.19",
           "bundled": true,
-          "dev": true,
           "requires": {
             "mime-db": "~1.35.0"
           }
@@ -9923,7 +9682,6 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -9931,7 +9689,6 @@
         "minizlib": {
           "version": "1.3.3",
           "bundled": true,
-          "dev": true,
           "requires": {
             "minipass": "^2.9.0"
           },
@@ -9939,7 +9696,6 @@
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -9950,7 +9706,6 @@
         "mississippi": {
           "version": "3.0.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "concat-stream": "^1.5.0",
             "duplexify": "^3.4.2",
@@ -9967,22 +9722,19 @@
         "mkdirp": {
           "version": "0.5.5",
           "bundled": true,
-          "dev": true,
           "requires": {
             "minimist": "^1.2.5"
           },
           "dependencies": {
             "minimist": {
               "version": "1.2.5",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             }
           }
         },
         "move-concurrently": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "aproba": "^1.1.1",
             "copy-concurrently": "^1.0.0",
@@ -9994,30 +9746,25 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             }
           }
         },
         "ms": {
           "version": "2.1.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "mute-stream": {
           "version": "0.0.7",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "nice-try": {
           "version": "1.0.5",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "node-fetch-npm": {
           "version": "2.0.2",
           "bundled": true,
-          "dev": true,
           "requires": {
             "encoding": "^0.1.11",
             "json-parse-better-errors": "^1.0.0",
@@ -10027,7 +9774,6 @@
         "node-gyp": {
           "version": "5.1.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "env-paths": "^2.2.0",
             "glob": "^7.1.4",
@@ -10045,7 +9791,6 @@
         "nopt": {
           "version": "4.0.3",
           "bundled": true,
-          "dev": true,
           "requires": {
             "abbrev": "1",
             "osenv": "^0.1.4"
@@ -10054,7 +9799,6 @@
         "normalize-package-data": {
           "version": "2.5.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "hosted-git-info": "^2.1.4",
             "resolve": "^1.10.0",
@@ -10065,7 +9809,6 @@
             "resolve": {
               "version": "1.10.0",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "path-parse": "^1.0.6"
               }
@@ -10075,7 +9818,6 @@
         "npm-audit-report": {
           "version": "1.3.2",
           "bundled": true,
-          "dev": true,
           "requires": {
             "cli-table3": "^0.5.0",
             "console-control-strings": "^1.1.0"
@@ -10084,20 +9826,17 @@
         "npm-bundled": {
           "version": "1.1.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "npm-normalize-package-bin": "^1.0.1"
           }
         },
         "npm-cache-filename": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "npm-install-checks": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
           "requires": {
             "semver": "^2.3.0 || 3.x || 4 || 5"
           }
@@ -10105,7 +9844,6 @@
         "npm-lifecycle": {
           "version": "3.1.4",
           "bundled": true,
-          "dev": true,
           "requires": {
             "byline": "^5.0.0",
             "graceful-fs": "^4.1.15",
@@ -10119,18 +9857,15 @@
         },
         "npm-logical-tree": {
           "version": "1.2.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "npm-normalize-package-bin": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "npm-package-arg": {
           "version": "6.1.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "hosted-git-info": "^2.7.1",
             "osenv": "^0.1.5",
@@ -10141,7 +9876,6 @@
         "npm-packlist": {
           "version": "1.4.8",
           "bundled": true,
-          "dev": true,
           "requires": {
             "ignore-walk": "^3.0.1",
             "npm-bundled": "^1.0.1",
@@ -10151,7 +9885,6 @@
         "npm-pick-manifest": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
           "requires": {
             "figgy-pudding": "^3.5.1",
             "npm-package-arg": "^6.0.0",
@@ -10161,7 +9894,6 @@
         "npm-profile": {
           "version": "4.0.4",
           "bundled": true,
-          "dev": true,
           "requires": {
             "aproba": "^1.1.2 || 2",
             "figgy-pudding": "^3.4.1",
@@ -10171,7 +9903,6 @@
         "npm-registry-fetch": {
           "version": "4.0.5",
           "bundled": true,
-          "dev": true,
           "requires": {
             "JSONStream": "^1.3.4",
             "bluebird": "^3.5.1",
@@ -10184,28 +9915,24 @@
           "dependencies": {
             "safe-buffer": {
               "version": "5.2.1",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             }
           }
         },
         "npm-run-path": {
           "version": "2.0.2",
           "bundled": true,
-          "dev": true,
           "requires": {
             "path-key": "^2.0.0"
           }
         },
         "npm-user-validate": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "npmlog": {
           "version": "4.1.2",
           "bundled": true,
-          "dev": true,
           "requires": {
             "are-we-there-yet": "~1.1.2",
             "console-control-strings": "~1.1.0",
@@ -10215,28 +9942,23 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "oauth-sign": {
           "version": "0.9.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "object-keys": {
           "version": "1.0.12",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "object.getownpropertydescriptors": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
           "requires": {
             "define-properties": "^1.1.2",
             "es-abstract": "^1.5.1"
@@ -10245,25 +9967,21 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "wrappy": "1"
           }
         },
         "opener": {
           "version": "1.5.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "os-locale": {
           "version": "3.1.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "execa": "^1.0.0",
             "lcid": "^2.0.0",
@@ -10273,7 +9991,6 @@
             "cross-spawn": {
               "version": "6.0.5",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "nice-try": "^1.0.4",
                 "path-key": "^2.0.1",
@@ -10285,7 +10002,6 @@
             "execa": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "cross-spawn": "^6.0.0",
                 "get-stream": "^4.0.0",
@@ -10300,13 +10016,11 @@
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "osenv": {
           "version": "0.1.5",
           "bundled": true,
-          "dev": true,
           "requires": {
             "os-homedir": "^1.0.0",
             "os-tmpdir": "^1.0.0"
@@ -10314,23 +10028,19 @@
         },
         "p-defer": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "p-finally": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "p-is-promise": {
           "version": "2.1.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "p-limit": {
           "version": "1.2.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "p-try": "^1.0.0"
           }
@@ -10338,20 +10048,17 @@
         "p-locate": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "p-limit": "^1.1.0"
           }
         },
         "p-try": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "package-json": {
           "version": "4.0.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "got": "^6.7.1",
             "registry-auth-token": "^3.0.1",
@@ -10362,7 +10069,6 @@
         "pacote": {
           "version": "9.5.12",
           "bundled": true,
-          "dev": true,
           "requires": {
             "bluebird": "^3.5.3",
             "cacache": "^12.0.2",
@@ -10399,7 +10105,6 @@
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -10410,7 +10115,6 @@
         "parallel-transform": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "cyclist": "~0.2.2",
             "inherits": "^2.0.3",
@@ -10420,7 +10124,6 @@
             "readable-stream": {
               "version": "2.3.6",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -10434,7 +10137,6 @@
             "string_decoder": {
               "version": "1.1.1",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
@@ -10443,58 +10145,47 @@
         },
         "path-exists": {
           "version": "3.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "path-is-inside": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "path-key": {
           "version": "2.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "path-parse": {
           "version": "1.0.6",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "performance-now": {
           "version": "2.1.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "pify": {
           "version": "3.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "prepend-http": {
           "version": "1.0.4",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "promise-inflight": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "promise-retry": {
           "version": "1.1.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "err-code": "^1.0.0",
             "retry": "^0.10.0"
@@ -10502,51 +10193,43 @@
           "dependencies": {
             "retry": {
               "version": "0.10.1",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             }
           }
         },
         "promzard": {
           "version": "0.3.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "read": "1"
           }
         },
         "proto-list": {
           "version": "1.2.4",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "protoduck": {
           "version": "5.0.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "genfun": "^5.0.0"
           }
         },
         "prr": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "pseudomap": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "psl": {
           "version": "1.1.29",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "pump": {
           "version": "3.0.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "end-of-stream": "^1.1.0",
             "once": "^1.3.1"
@@ -10555,7 +10238,6 @@
         "pumpify": {
           "version": "1.5.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "duplexify": "^3.6.0",
             "inherits": "^2.0.3",
@@ -10565,7 +10247,6 @@
             "pump": {
               "version": "2.0.1",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
@@ -10575,23 +10256,19 @@
         },
         "punycode": {
           "version": "1.4.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "qrcode-terminal": {
           "version": "0.12.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "qs": {
           "version": "6.5.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "query-string": {
           "version": "6.8.2",
           "bundled": true,
-          "dev": true,
           "requires": {
             "decode-uri-component": "^0.2.0",
             "split-on-first": "^1.0.0",
@@ -10600,13 +10277,11 @@
         },
         "qw": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "rc": {
           "version": "1.2.8",
           "bundled": true,
-          "dev": true,
           "requires": {
             "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
@@ -10616,15 +10291,13 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.5",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             }
           }
         },
         "read": {
           "version": "1.0.7",
           "bundled": true,
-          "dev": true,
           "requires": {
             "mute-stream": "~0.0.4"
           }
@@ -10632,7 +10305,6 @@
         "read-cmd-shim": {
           "version": "1.0.5",
           "bundled": true,
-          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2"
           }
@@ -10640,7 +10312,6 @@
         "read-installed": {
           "version": "4.0.3",
           "bundled": true,
-          "dev": true,
           "requires": {
             "debuglog": "^1.0.1",
             "graceful-fs": "^4.1.2",
@@ -10654,7 +10325,6 @@
         "read-package-json": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "glob": "^7.1.1",
             "graceful-fs": "^4.1.2",
@@ -10666,7 +10336,6 @@
         "read-package-tree": {
           "version": "5.3.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "read-package-json": "^2.0.0",
             "readdir-scoped-modules": "^1.0.0",
@@ -10676,7 +10345,6 @@
         "readable-stream": {
           "version": "3.6.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -10686,7 +10354,6 @@
         "readdir-scoped-modules": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "debuglog": "^1.0.1",
             "dezalgo": "^1.0.0",
@@ -10697,7 +10364,6 @@
         "registry-auth-token": {
           "version": "3.4.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "rc": "^1.1.6",
             "safe-buffer": "^5.0.1"
@@ -10706,7 +10372,6 @@
         "registry-url": {
           "version": "3.1.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "rc": "^1.0.1"
           }
@@ -10714,7 +10379,6 @@
         "request": {
           "version": "2.88.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "aws-sign2": "~0.7.0",
             "aws4": "^1.8.0",
@@ -10740,28 +10404,23 @@
         },
         "require-directory": {
           "version": "2.1.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "require-main-filename": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "resolve-from": {
           "version": "4.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "retry": {
           "version": "0.12.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "rimraf": {
           "version": "2.7.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "glob": "^7.1.3"
           }
@@ -10769,50 +10428,42 @@
         "run-queue": {
           "version": "1.0.3",
           "bundled": true,
-          "dev": true,
           "requires": {
             "aproba": "^1.1.1"
           },
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             }
           }
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "semver": {
           "version": "5.7.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "semver-diff": {
           "version": "2.1.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "semver": "^5.0.3"
           }
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "sha": {
           "version": "3.0.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2"
           }
@@ -10820,35 +10471,29 @@
         "shebang-command": {
           "version": "1.2.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "shebang-regex": "^1.0.0"
           }
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "slide": {
           "version": "1.1.6",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "smart-buffer": {
           "version": "4.1.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "socks": {
           "version": "2.3.3",
           "bundled": true,
-          "dev": true,
           "requires": {
             "ip": "1.1.5",
             "smart-buffer": "^4.1.0"
@@ -10857,7 +10502,6 @@
         "socks-proxy-agent": {
           "version": "4.0.2",
           "bundled": true,
-          "dev": true,
           "requires": {
             "agent-base": "~4.2.1",
             "socks": "~2.3.2"
@@ -10866,7 +10510,6 @@
             "agent-base": {
               "version": "4.2.1",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "es6-promisify": "^5.0.0"
               }
@@ -10875,13 +10518,11 @@
         },
         "sorted-object": {
           "version": "2.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "sorted-union-stream": {
           "version": "2.1.3",
           "bundled": true,
-          "dev": true,
           "requires": {
             "from2": "^1.3.0",
             "stream-iterate": "^1.1.0"
@@ -10890,7 +10531,6 @@
             "from2": {
               "version": "1.3.0",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "inherits": "~2.0.1",
                 "readable-stream": "~1.1.10"
@@ -10898,13 +10538,11 @@
             },
             "isarray": {
               "version": "0.0.1",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "readable-stream": {
               "version": "1.1.14",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.1",
@@ -10914,15 +10552,13 @@
             },
             "string_decoder": {
               "version": "0.10.31",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             }
           }
         },
         "spdx-correct": {
           "version": "3.0.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "spdx-expression-parse": "^3.0.0",
             "spdx-license-ids": "^3.0.0"
@@ -10930,13 +10566,11 @@
         },
         "spdx-exceptions": {
           "version": "2.1.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "spdx-expression-parse": {
           "version": "3.0.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "spdx-exceptions": "^2.1.0",
             "spdx-license-ids": "^3.0.0"
@@ -10944,18 +10578,15 @@
         },
         "spdx-license-ids": {
           "version": "3.0.5",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "split-on-first": {
           "version": "1.1.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "sshpk": {
           "version": "1.14.2",
           "bundled": true,
-          "dev": true,
           "requires": {
             "asn1": "~0.2.3",
             "assert-plus": "^1.0.0",
@@ -10971,7 +10602,6 @@
         "ssri": {
           "version": "6.0.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "figgy-pudding": "^3.5.1"
           }
@@ -10979,7 +10609,6 @@
         "stream-each": {
           "version": "1.2.2",
           "bundled": true,
-          "dev": true,
           "requires": {
             "end-of-stream": "^1.1.0",
             "stream-shift": "^1.0.0"
@@ -10988,7 +10617,6 @@
         "stream-iterate": {
           "version": "1.2.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "readable-stream": "^2.1.5",
             "stream-shift": "^1.0.0"
@@ -10997,7 +10625,6 @@
             "readable-stream": {
               "version": "2.3.6",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -11011,7 +10638,6 @@
             "string_decoder": {
               "version": "1.1.1",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
@@ -11020,18 +10646,15 @@
         },
         "stream-shift": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "strict-uri-encode": {
           "version": "2.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "string-width": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
             "strip-ansi": "^4.0.0"
@@ -11039,18 +10662,15 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "strip-ansi": {
               "version": "4.0.0",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "ansi-regex": "^3.0.0"
               }
@@ -11060,45 +10680,38 @@
         "string_decoder": {
           "version": "1.3.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "safe-buffer": "~5.2.0"
           },
           "dependencies": {
             "safe-buffer": {
               "version": "5.2.0",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             }
           }
         },
         "stringify-package": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
         },
         "strip-eof": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "supports-color": {
           "version": "5.4.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -11106,7 +10719,6 @@
         "tar": {
           "version": "4.4.13",
           "bundled": true,
-          "dev": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
@@ -11120,7 +10732,6 @@
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -11131,25 +10742,21 @@
         "term-size": {
           "version": "1.2.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "execa": "^0.7.0"
           }
         },
         "text-table": {
           "version": "0.2.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "through": {
           "version": "2.3.8",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "through2": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
           "requires": {
             "readable-stream": "^2.1.5",
             "xtend": "~4.0.1"
@@ -11158,7 +10765,6 @@
             "readable-stream": {
               "version": "2.3.6",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -11172,7 +10778,6 @@
             "string_decoder": {
               "version": "1.1.1",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
@@ -11181,18 +10786,15 @@
         },
         "timed-out": {
           "version": "4.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "tiny-relative-date": {
           "version": "1.3.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "tough-cookie": {
           "version": "2.4.3",
           "bundled": true,
-          "dev": true,
           "requires": {
             "psl": "^1.1.24",
             "punycode": "^1.4.1"
@@ -11201,7 +10803,6 @@
         "tunnel-agent": {
           "version": "0.6.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "safe-buffer": "^5.0.1"
           }
@@ -11209,28 +10810,23 @@
         "tweetnacl": {
           "version": "0.14.5",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "typedarray": {
           "version": "0.0.6",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "uid-number": {
           "version": "0.0.6",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "umask": {
           "version": "1.1.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "unique-filename": {
           "version": "1.1.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "unique-slug": "^2.0.0"
           }
@@ -11238,7 +10834,6 @@
         "unique-slug": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "imurmurhash": "^0.1.4"
           }
@@ -11246,25 +10841,21 @@
         "unique-string": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "crypto-random-string": "^1.0.0"
           }
         },
         "unpipe": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "unzip-response": {
           "version": "2.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "update-notifier": {
           "version": "2.5.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "boxen": "^1.2.1",
             "chalk": "^2.0.1",
@@ -11281,38 +10872,32 @@
         "url-parse-lax": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "prepend-http": "^1.0.1"
           }
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "util-extend": {
           "version": "1.0.3",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "util-promisify": {
           "version": "2.1.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "object.getownpropertydescriptors": "^2.0.3"
           }
         },
         "uuid": {
           "version": "3.3.3",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "validate-npm-package-license": {
           "version": "3.0.4",
           "bundled": true,
-          "dev": true,
           "requires": {
             "spdx-correct": "^3.0.0",
             "spdx-expression-parse": "^3.0.0"
@@ -11321,7 +10906,6 @@
         "validate-npm-package-name": {
           "version": "3.0.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "builtins": "^1.0.3"
           }
@@ -11329,7 +10913,6 @@
         "verror": {
           "version": "1.10.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "assert-plus": "^1.0.0",
             "core-util-is": "1.0.2",
@@ -11339,7 +10922,6 @@
         "wcwidth": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "defaults": "^1.0.3"
           }
@@ -11347,20 +10929,17 @@
         "which": {
           "version": "1.3.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "isexe": "^2.0.0"
           }
         },
         "which-module": {
           "version": "2.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "wide-align": {
           "version": "1.1.2",
           "bundled": true,
-          "dev": true,
           "requires": {
             "string-width": "^1.0.2"
           },
@@ -11368,7 +10947,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -11380,7 +10958,6 @@
         "widest-line": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "string-width": "^2.1.1"
           }
@@ -11388,7 +10965,6 @@
         "worker-farm": {
           "version": "1.7.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "errno": "~0.1.7"
           }
@@ -11396,7 +10972,6 @@
         "wrap-ansi": {
           "version": "2.1.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "string-width": "^1.0.1",
             "strip-ansi": "^3.0.1"
@@ -11405,7 +10980,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -11416,13 +10990,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "write-file-atomic": {
           "version": "2.4.3",
           "bundled": true,
-          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.11",
             "imurmurhash": "^0.1.4",
@@ -11431,28 +11003,23 @@
         },
         "xdg-basedir": {
           "version": "3.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "xtend": {
           "version": "4.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "y18n": {
           "version": "4.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "yargs": {
           "version": "11.1.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "cliui": "^4.0.0",
             "decamelize": "^1.1.1",
@@ -11470,15 +11037,13 @@
           "dependencies": {
             "y18n": {
               "version": "3.2.1",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             }
           }
         },
         "yargs-parser": {
           "version": "9.0.2",
           "bundled": true,
-          "dev": true,
           "requires": {
             "camelcase": "^4.1.0"
           }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "bourbon": "^5.1",
     "browserslist": "^4.8.7",
     "css-loader": "^2.1",
-    "decanter": "^6.0.5",
+    "decanter": "^6.1.0",
     "drupal-behaviors-loader": "^1.0",
     "element-closest-polyfill": "^1.0.0",
     "element-matches-polyfill": "^1.0.0",


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- The theme used an older version of decanter, and the global footer broke with recent accessibility labels like 'link is external'

# Review By (Date)
- 10/6 needs to be all ready BEFORE the d8core update releases Thursday night october 8th

# Urgency
- How critical is this PR? HIGH - very noticeable issues with global footer.

# Steps to Test

Issue looks like this: 
![image](https://user-images.githubusercontent.com/12898896/95142161-4c02ab00-0730-11eb-9bdc-32ed65397827.png)


1. See the site https://saauserguide-test.sites.stanford.edu/ Then you'll see that the global footer looks correct. 
2. Note that the file changed here matches the same decanter version that Jen is using for soe: https://github.com/SU-SOE/soe_basic/blob/8.x-1.x/package.json
3. If you want to compare to see it not working correctly, you can log in to acquia cloud and change it back to 1.x to see it broken: 
4. https://www.test-cardinalsites.acsitefactory.com/mysites/17051/theme-repository click 'change theme repository' and set to 1.x, save.
3. Then go back to the list of all sites and click 'clear caches' for this test site, check in about 2 minutes that it is broken on 1.x,


# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- JIRA ticket ADAPT-885
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
