### PR TITLE
ADAPT-1858: D9 compatibility in theme info file

### DIFF
--- a/dist/templates/decanter/components/local-footer/local-footer.twig
+++ b/dist/templates/decanter/components/local-footer/local-footer.twig
@@ -112,6 +112,7 @@
         The address is optional so don't put non-address content in it.
         Use the `cell1` variable instead.
       #}
+      {# could update this later with new render options #}
       {% if address|render|striptags|trim is not empty %}
       <h2 class="su-sr-only-element">Address</h2>
       <address class="su-local-footer__address">

--- a/saa_victoria_subtheme.info.yml
+++ b/saa_victoria_subtheme.info.yml
@@ -3,7 +3,7 @@ type: theme
 description: 'Stanford Alumni Association: Victoria Theme.'
 package: Stanford
 version: 8.x-1.7-dev
-core: 8.x
+core_version_requirement: '^8.8 || ^9'
 base theme: stanford_basic
 libraries:
   - saa_victoria_subtheme/allpages

--- a/saa_victoria_subtheme.info.yml
+++ b/saa_victoria_subtheme.info.yml
@@ -2,7 +2,7 @@ name: Victoria
 type: theme
 description: 'Stanford Alumni Association: Victoria Theme.'
 package: Stanford
-version: 8.x-1.7-dev
+version: 8.x-1.7
 core_version_requirement: '^8.8 || ^9'
 base theme: stanford_basic
 libraries:

--- a/templates/components/fat-footer/saa-fat-footer.html.twig
+++ b/templates/components/fat-footer/saa-fat-footer.html.twig
@@ -2,20 +2,20 @@
 {% import "@jumpstart_ui/macros/field-links-to-list.twig" as linklist %}
 {% import "@jumpstart_ui/macros/field-links-to-social-list.twig" as sociallist %}
 
-{%- set weblogin_text = weblogin_text|render|striptags('<drupal-render-placeholder>')|trim -%}
+{%- set weblogin_text = weblogin_text|render_clean -%}
 {%- if weblogin_text is empty -%}
   {%- set weblogin_url = '' -%}
 {%- endif -%}
-{%- set lockup_title = lockup_title|render|striptags('<drupal-render-placeholder>')|trim|convert_encoding('UTF-8', 'HTML-ENTITIES') -%}
-{%- set signup_form_method = signup_form_method|render|striptags('<drupal-render-placeholder>')|trim -%}
-{%- set signup_form_action = signup_form_action|render|striptags('<drupal-render-placeholder>')|trim|convert_encoding('UTF-8', 'HTML-ENTITIES') -%}
-{%- set signup_form_field_submit_value = signup_form_field_submit_value|render|striptags('<drupal-render-placeholder>')|trim -%}
+{%- set lockup_title = lockup_title|render_clean -%}
+{%- set signup_form_method = signup_form_method|render_clean -%}
+{%- set signup_form_action = signup_form_action|render_clean -%}
+{%- set signup_form_field_submit_value = signup_form_field_submit_value|render_clean -%}
 {%- set action_links = linklist.create_list(action_links) -%}
 {%- set social_links = sociallist.create_list(social_links) -%}
 {#{%- set primary_links = linklist.create_list(primary_links) -%}#}
 {#{%- set secondary_links = linklist.create_list(secondary_links) -%}#}
-{#{%- set primary_links_header = primary_links_header|render|striptags('<drupal-render-placeholder><a>')|trim -%}#}
-{#{%- set secondary_links_header = secondary_links_header|render|striptags('<drupal-render-placeholder><a>')|trim -%}#}
+{#{%- set primary_links_header = primary_links_header|render_clean -%}#}
+{#{%- set secondary_links_header = secondary_links_header|render_clean -%}#}
 
 {% if attributes is not empty %}
   {% set attributes = attributes.removeClass('su-local-footer') %}


### PR DESCRIPTION
# READY

# Summary
- Prepare SAA Theme to be officially compatible with d9

# Review By (Date)
- 2 /22/ 2021 once it is confirmed working

# Urgency
- Medium, high. Already had d9 launch, sites are functioning, but need this updated today.

# Steps to Test

1. Check out the branch locally or test through https://saauserguide-test.sites.stanford.edu/
2. Confirm on the Appearance page that the theme is updated and doesn't give an error about D9 compatibility.
![image](https://user-images.githubusercontent.com/12898896/108751532-94fca580-74ff-11eb-92cb-4574bcdc7030.png)
![image](https://user-images.githubusercontent.com/12898896/108751558-9ded7700-74ff-11eb-9cb0-6e0392854d01.png)

3. Confirm new theme version 8.1.7
4. Confirm logged in you don't see any errors going around on any pages
5. Confirm anonymous user doesn't see any issues on main pages.
6. Confirm locally that you can pull down the branch, clear caches, uninstall the theme and reinstall the theme without breaking the site or having any issues/errors.
7. There should be no visual change to end-users

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?
All SAA sites currently are on a d8-only-compatibility version, we need to update them all today. There should be no visual change to end users

# Associated Issues and/or People
- JIRA ticket ADAPT-1858
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
