### PR TITLE
ADAPT-3777 : Update fat footer

### DIFF
--- a/templates/components/fat-footer/saa-fat-footer.html.twig
+++ b/templates/components/fat-footer/saa-fat-footer.html.twig
@@ -52,8 +52,8 @@
     </address>
   {# Stylized links. See local-footer.json for structure for macro. #}
     <ul class="su-local-footer__action-links">
-      <li><a href="https://alumni.stanford.edu/get/page/directory/search?pgOrg=saa">Find an alum</a></li>
-      <li><a href="https://alumni.stanford.edu/tools/mail?level=12&groupname=saa&pgOrg=saa&dbc=y">Check your alumni email</a></li>
+      <li><a href="https://cardinalalumni.stanford.edu/get/page/directory/search?pgOrg=saa">Find an alum</a></li>
+      <li><a href="https://cardinalalumni.stanford.edu/tools/mail?level=12&groupname=saa&pgOrg=saa&dbc=y">Check your alumni email</a></li>
       <li><a href="http://giving.stanford.edu/">Give to Stanford</a></li>
     </ul>
   {# Stylized links. See local-footer.json for structure for macro. #}
@@ -97,10 +97,10 @@
   </ul>
 
   <div class="saa-footer--legal-links">
-    <a href="https://alumni.stanford.edu/get/page/accessibility">Accessibility</a> |
-    <a href="https://alumni.stanford.edu/get/page/privacy">Privacy Policy</a> |
-    <a href="https://alumni.stanford.edu/get/page/terms">Terms of Use</a> |
-    <a href="https://alumni.stanford.edu/get/page/codeofconduct">Code of Conduct</a>
+    <a href="https://alumni.stanford.edu/accessibility/">Accessibility</a> |
+    <a href="https://alumni.stanford.edu/privacy/">Privacy Policy</a> |
+    <a href="https://alumni.stanford.edu/terms/">Terms of Use</a> |
+    <a href="https://alumni.stanford.edu/code-of-conduct/">Code of Conduct</a>
   </div>
 {% endblock %}
 
@@ -109,8 +109,8 @@
   <nav class="saa-local-footer__links-section saa-local-footer__links-section-1" aria-label="saa footer section 1">
     <h2 class="su-local-footer__list-heading">Events</h2>
     <ul class="saa-local-footer__links-column-1">
-      <li><a href="https://alumni.stanford.edu/get/page/events">Explore all events</a></li>
-      <li><a href="https://alumni.stanford.edu/get/page/life-long-learning/learn">Virtual events</a></li>
+      <li><a href="https://cardinalalumni.stanford.edu/get/page/events">Explore all events</a></li>
+      <li><a href="https://alumni.stanford.edu/resources/learn/">Virtual events</a></li>
       <li><a href="https://reunion.stanford.edu/">Reunion Homecoming</a></li>
     </ul>
   </nav>
@@ -118,7 +118,7 @@
   <nav class="saa-local-footer__links-section saa-local-footer__links-section-2" aria-label="saa footer section 2">
     <h2 class="su-local-footer__list-heading">Communities</h2>
     <ul class="saa-local-footer__links-column-2">
-      <li><a href="https://alumni.stanford.edu/get/page/groups/main">Clubs & groups</a></li>
+      <li><a href="https://alumni.stanford.edu/groups/">Clubs & groups</a></li>
       <li><a href="https://youngalumni.alumni.stanford.edu/">Young Alumni</a></li>
 {#      <li><a href="/">Grad Alumni</a></li>#}
       <li><a href="https://students.alumni.stanford.edu/">Students</a></li>
@@ -129,30 +129,30 @@
     <h2 class="su-local-footer__list-heading">Reading & resources</h2>
     <ul class="saa-local-footer__links-column-3">
 {#      <li><a href="/">News/Announcements</a></li>#}
-      <li><a href="https://alumni.stanford.edu/get/page/life-long-learning/learn">Webcasts & podcasts</a></li>
+      <li><a href="https://alumni.stanford.edu/resources/learn/">Webcasts & podcasts</a></li>
       <li><a href="https://stanfordmag.org/">STANFORD magazine</a></li>
-      <li><a href="https://alumni.stanford.edu/get/page/career">Career connections</a></li>
-      <li><a href="https://alumni.stanford.edu/get/page/life-long-learning/learn-join">Newsletters</a></li>
+      <li><a href="https://careers.alumni.stanford.edu">Career connections</a></li>
+      <li><a href="https://alumni.stanford.edu/resources/newsletters/">Newsletters</a></li>
     </ul>
   </nav>
   <nav class="saa-local-footer__links-section saa-local-footer__links-section-4" aria-label="saa footer section 4">
     <h2 class="su-local-footer__list-heading">Programs & perks</h2>
     <ul class="saa-local-footer__links-column-4">
-      <li><a href="https://alumni.stanford.edu/get/page/perks/index">Alumni perks</a></li>
-      <li><a href="https://alumni.stanford.edu/get/page/membership/home">Alumni membership</a></li>
+      <li><a href="https://alumni.stanford.edu/perks/">Alumni perks</a></li>
+      <li><a href="https://alumni.stanford.edu/membership/e">Alumni membership</a></li>
       <li><a href="https://sierracamp.alumni.stanford.edu/">Sierra programs</a></li>
-      <li><a href="https://alumni.stanford.edu/get/page/travel-study/overview">Travel/Study</a></li>
+      <li><a href="https://cardinalalumni.stanford.edu/get/page/travel-study/overview">Travel/Study</a></li>
       <li><a href="https://partners.vinoshipper.com/stanford">Wine collection</a></li>
-      <li><a href="https://alumni.stanford.edu/get/page/resources/shop/home">Alumni store</a></li>
+      <li><a href="https://cardinalalumni.stanford.edu/get/page/resources/shop/home">Alumni store</a></li>
     </ul>
   </nav>
   {# Link SEction 1 - top left links. #}
   <nav class="saa-local-footer__links-section saa-local-footer__links-section-5" aria-label="saa footer section 5">
     <h2 class="su-local-footer__list-heading">Volunteer</h2>
     <ul class="saa-local-footer__links-column-5">
-      <li><a href="https://alumni.stanford.edu/get/page/landing/volunteering">Getting started</a></li>
+      <li><a href="https://alumni.stanford.edu/volunteer/">Getting started</a></li>
       <li><a href="https://associates.alumni.stanford.edu/">Stanford Associates</a></li>
-      <li><a href="https://alumni.stanford.edu/get/page/volunteering/beyondthefarm/">Beyond the Farm</a></li>
+      <li><a href="https://cardinalalumni.stanford.edu/get/page/volunteering/beyondthefarm/">Beyond the Farm</a></li>
       <li><a href="http://trusteenominations.alumni.stanford.edu/">Trustee nominations</a></li>
     </ul>
   </nav>
@@ -160,10 +160,10 @@
   <nav class="saa-local-footer__links-section saa-local-footer__links-section-6" aria-label="saa footer section 6">
     <h2 class="su-local-footer__list-heading">About</h2>
     <ul class="saa-local-footer__links-column-6">
-      <li><a href="https://alumni.stanford.edu/get/page/about-us">About SAA</a></li>
+      <li><a href="https://alumni.stanford.edu/about/">About SAA</a></li>
       <li><a href="https://alumnicenter.alumni.stanford.edu/">Frances C. Arrillaga Alumni Center</a></li>
       <li><a href="https://alumnicenterevents.alumni.stanford.edu/">Rent event space</a></li>
-      <li><a href="https://alumni.stanford.edu/get/page/help/contact-us">Contact us</a></li>
+      <li><a href="https://alumni.stanford.edu/about/contact/">Contact us</a></li>
     </ul>
   </nav>
 {% endblock %}


### PR DESCRIPTION
Update fat footer with links!

# READY FOR REVIEW

# Summary
Updating links so they don't have to go through redirects.

# Review By (Date)
- Anytime

# Criticality
-Not terribly. Redirects will take care of these links

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Click on fat footer links
3. Make sure that any pages that have /get/page in the footer link is prefaced with cardinalalumni.stanford.edu


# Associated Issues and/or People
- JIRA ticket(s)
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# Resources
- [AMP Tool](https://stanford.levelaccess.net/index.php)
- [Accessibility Manual Test Script](https://docs.google.com/document/d/1ZXJ9RIUNXsS674ow9j3qJ2g1OAkCjmqMXl0Gs8XHEPQ/edit?usp=sharing)
- [HTML Validator](https://validator.w3.org/)
- [Browserstack](https://live.browserstack.com/dashboard) and link to [Browserstack Credentials](https://asconfluence.stanford.edu/confluence/display/SWS/External+Account+Credentials)
